### PR TITLE
Allow custom encoders rather than JSON only

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,16 @@
 
 [![CircleCI](https://circleci.com/gh/kdxu/loggix/tree/master.svg?style=svg)](https://circleci.com/gh/kdxu/loggix/tree/master)
 
-- `Loggix` is a custom Logger Backend with easy configiration.
+* `Loggix` is a custom Logger Backend with easy configuration.
 
 using `GenEvent`.
 
 ## Concept
 
-- Configiration of log rotation
-- JSON, XML Encode feature
-- Metadata filter
+* Configuration of log rotation
+* JSON, Logfmt or whatever module implements an encoding function which accepts a `Map` as
+  input
+* Metadata filter
 
 ## Installation
 
@@ -22,9 +23,10 @@ by adding `loggix` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:loggix, "~> 0.0.7"}]
+  [{:loggix, "~> 0.0.8"}]
 end
 ```
+
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
 be found at [https://hexdocs.pm/loggix](https://hexdocs.pm/loggix).
@@ -39,7 +41,7 @@ config :logger,
 config :logger, :error_log,
   path: "var/log/error_log",
   level: :error,
-  json_encoder: Poison,
+  encoder: {Poison, :encode!},
   metadata: [:user_id, :is_auth],
   rotate: %{max_bytes: 4096, keep: 6},
   metadata_filter: [:is_app]

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Loggix.Mixfile do
       dialyzer: [ignore_warnings: ".dialyzerignore"],
       package: package(),
       description: description(),
-      deps: deps(),
+      deps: deps()
     ]
   end
 
@@ -21,7 +21,7 @@ defmodule Loggix.Mixfile do
     [
       maintainers: ["kdxu"],
       licenses: ["MIT"],
-      links: %{"GitHub" => "https://github.com/kdxu/loggix"},
+      links: %{"GitHub" => "https://github.com/kdxu/loggix"}
     ]
   end
 
@@ -32,8 +32,9 @@ defmodule Loggix.Mixfile do
   defp deps() do
     [
       {:poison, "~> 3.1.0", only: [:test]},
+      {:logfmt, "~> 3.3", only: [:test]},
       {:dialyxir, "~> 0.5.1", only: [:test], runtime: false},
-      {:ex_doc, "~> 0.18.1", only: [:dev], runtime: false},
+      {:ex_doc, "~> 0.18.1", only: [:dev], runtime: false}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,7 @@
-%{"dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
+%{
+  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"}}
+  "logfmt": {:hex, :logfmt, "3.3.0", "f863e19b9cac952f177f878074ec9304bb132eb9034306e75216dee88ca744d9", [:mix], [], "hexpm"},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
+}

--- a/test/loggix_test.exs
+++ b/test/loggix_test.exs
@@ -4,28 +4,29 @@ defmodule LoggixTest do
 
   @backend {Loggix, :test}
 
-  Logger.add_backend(@backend, [flush: true])
+  Logger.add_backend(@backend, flush: true)
 
   setup do
-    config([path: "test/logs/test.log", level: :debug])
-    on_exit fn ->
+    config(path: "test/logs/test.log", level: :debug)
+
+    on_exit(fn ->
       path() && File.rm_rf!(Path.dirname(path()))
-    end
+    end)
   end
 
   test "does not crash if path isn't set" do
-    config([path: nil])
+    config(path: nil)
     Logger.debug("foo")
     assert {:error, :already_present} = Logger.add_backend(@backend)
   end
 
   test "can configure metadata_filter" do
-    config([metadata_filter: [test_key: true]])
+    config(metadata_filter: [test_key: true])
     Logger.debug("cat😾", test_key: false)
     Logger.debug("dog🐶", test_key: true)
     refute log() =~ "cat😾"
     assert log() =~ "dog🐶"
-    config([metadata_filter: nil])
+    config(metadata_filter: nil)
   end
 
   test "creates log file" do
@@ -41,25 +42,25 @@ defmodule LoggixTest do
   end
 
   test "can configure format" do
-    config([format: "$message [$level]\n"])
+    config(format: "$message [$level]\n")
 
     Logger.debug("hello")
     assert log() =~ "hello [debug]"
   end
 
   test "can configure metadata" do
-    config([metadata: [:user_id, :is_login], format: "$metadata[$level] $message\n"])
+    config(metadata: [:user_id, :is_login], format: "$metadata[$level] $message\n")
 
     Logger.debug("hello")
     assert log() =~ "hello"
 
     Logger.debug("hello", user_id: "xxx-xxx-xxx-xxx", is_login: true)
     assert log() =~ "user_id=xxx-xxx-xxx-xxx is_login=true [debug] hello"
-    config([metadata: nil])
+    config(metadata: nil)
   end
 
   test "can configure level" do
-    config([level: :info])
+    config(level: :info)
 
     Logger.debug("hello")
     refute File.exists?(path())
@@ -67,46 +68,46 @@ defmodule LoggixTest do
 
   test "can configure path" do
     new_path = "test/logs/test.log.2"
-    config([path: new_path])
+    config(path: new_path)
     assert new_path == path()
   end
 
   test "log file rotate" do
-    config([format: "$message\n"])
-    config([rotate: %{max_bytes: 4, keep: 4}])
+    config(format: "$message\n")
+    config(rotate: %{max_bytes: 4, keep: 4})
 
     Logger.debug("rotate1")
     Logger.debug("rotate2")
     Logger.debug("rotate3")
 
     p = path()
-    assert File.read!("#{p}.2")  == "rotate1\n"
-    assert File.read!("#{p}.1")  == "rotate2\n"
-    assert File.read!(p)         == "rotate3\n"
+    assert File.read!("#{p}.2") == "rotate1\n"
+    assert File.read!("#{p}.1") == "rotate2\n"
+    assert File.read!(p) == "rotate3\n"
 
-    config([rotate: nil])
+    config(rotate: nil)
   end
 
   test "log file does not rotate" do
-    config([format: "$message\n"])
-    config([rotate: %{max_bytes: 50, keep: 4}])
+    config(format: "$message\n")
+    config(rotate: %{max_bytes: 50, keep: 4})
 
     words = ["rotate1", "rotate2", "rotate3", "rotate4", "rotate5"]
-    words |> Enum.map(&(Logger.debug(&1)))
+    words |> Enum.map(&Logger.debug(&1))
 
     assert log() == Enum.join(words, "\n") <> "\n"
 
-    config([rotate: nil])
+    config(rotate: nil)
   end
 
-  test "json-encoded log" do
-    config([json_encoder: Poison, metadata: [:user_id]])
+  test "custom encoded log" do
+    config(encoder: {Poison, :encode!}, metadata: [:user_id])
     Logger.debug("hello", user_id: "xxx=xxxx")
     msg = Poison.decode!(log())
     assert msg["message"] == "hello"
     assert msg["user_id"] == "xxx=xxxx"
-    config([json_encoder: nil])
-    config([metadata: []])
+    config(encoder: nil)
+    config(metadata: [])
   end
 
   defp path() do

--- a/test/loggix_test.exs
+++ b/test/loggix_test.exs
@@ -100,12 +100,30 @@ defmodule LoggixTest do
     config(rotate: nil)
   end
 
-  test "custom encoded log" do
+  test "custom encoded log with JSON (Poison)" do
     config(encoder: {Poison, :encode!}, metadata: [:user_id])
     Logger.debug("hello", user_id: "xxx=xxxx")
     msg = Poison.decode!(log())
     assert msg["message"] == "hello"
     assert msg["user_id"] == "xxx=xxxx"
+    config(encoder: nil)
+    config(metadata: [])
+  end
+
+  test "custom encoded log with structured format (Logfmt)" do
+    config(encoder: {Logfmt, :encode}, metadata: [:user_id])
+
+    Logger.debug("hello", user_id: "xxx=xxxx")
+
+    assert %{
+             "level" => "debug",
+             "message" => "hello",
+             "timestamp" => _,
+             "user_id" => "xxx=xxxx"
+           } = Logfmt.decode(log())
+
+    IO.puts(log())
+
     config(encoder: nil)
     config(metadata: [])
   end


### PR DESCRIPTION
Hello there,

this PR allows to pass whatever module or function accepts a `Map` as input and returns a formatted string.

I think there's still something to adjust with output but it works and tests are passing. There's also a test for [Logfmt](https://github.com/jclem/logfmt-elixir).

Hope you'll enjoy it ;-)